### PR TITLE
Add Types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setuptools.setup(
         "dataclasses>=0.6",
         "dataclasses-json>=0.5.7",
         "aiobotocore>=2.3.0"
-    ]
+    ],
+    package_data="py.typed"
 )

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setuptools.setup(
         "dataclasses-json>=0.5.7",
         "aiobotocore>=2.3.0"
     ],
-    package_data="py.typed"
+    package_data={"near_lake_framework": ["py.typed"]}
 )


### PR DESCRIPTION
All libraries depending on this package are running into this mypy error:

```
error: Skipping analyzing "near_lake_framework": module is installed, but missing library stubs or py.typed marker  [import-untyped]
note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

It should be as straightforward as adding this empty `py.typed` file and including it in the setup.py file.


## Test Plan

1. Build the project locally `python -m build`.
2. Install the local build in a project that depends on it (e.g. https://github.com/near/gas-station-event-indexer) `pip install -e ../near_lake_framework`
3. Run `mypy` (see no more missing library stubs warnings)... 

After step 1 you can also unzip the build and see that the `py.typed` file is included in the build.

Note that there were additional type errors (referenced in #10). If this is accepted this PR also closes #10.

I think we should also BUMP the required python version of this package to at least `3.8`, but preferably `>=3.9`.

