### PR TITLE
Downgrade Missing Shard Log

### DIFF
--- a/src/near_lake_framework/s3_fetchers.py
+++ b/src/near_lake_framework/s3_fetchers.py
@@ -70,7 +70,7 @@ async def fetch_shard_or_retry(
             return near_primitives.IndexerShard.from_json(body)
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
-                logging.warning("Failed to fetch shard %s - doesn't exist", shard_key)
+                logging.debug("Failed to fetch shard %s - doesn't exist", shard_key)
             else:
                 traceback.print_exc()
         except EndpointConnectionError as e:


### PR DESCRIPTION
Not sure if I fully understand what it means when a shard is missing, but it seems to happen incredibly often (at least on testnet). So much that other projects depending on this are bombarded with warning logs (e.g. https://github.com/near/gas-station-event-indexer/pull/10#discussion_r1620847194). 

This PR proposes to downgrade this to a debug log so that dependent projects can silence them without explicitly filtering them out.