### PR TITLE
chore: rename blocks_preload_pool_size to preload_pool_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Available parameters:
 - `s3_bucket_name: str` - provide the AWS S3 bucket name (`near-lake-testnet`, `near-lake-mainnet` or yours if you run your own NEAR Lake)
 - `s3_region_name: str` - provide the region for AWS S3 bucket
 - `start_block_height: BlockHeight` - block height to start the stream from
-- `blocks_preload_pool_size: int` - provide the number of blocks to preload (default: 200)
+- `preload_pool_size: int` - provide the number of blocks to preload (default: 200)
 
 ## Cost estimates
 

--- a/src/near_lake_framework/__init__.py
+++ b/src/near_lake_framework/__init__.py
@@ -48,7 +48,7 @@ class LakeConfig:
     aws_access_key_id: str
     aws_secret_key: str
     start_block_height: near_primitives.BlockHeight
-    blocks_preload_pool_size: int = 200
+    preload_pool_size: int = 200
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -84,7 +84,7 @@ async def start(config: LakeConfig, streamer_messages_queue: asyncio.Queue):
                 s3_client,
                 config.s3_bucket_name,
                 start_from_block_height,
-                config.blocks_preload_pool_size * 2,
+                config.preload_pool_size * 2,
             )
 
             if not block_heights_prefixes:
@@ -149,7 +149,7 @@ async def start(config: LakeConfig, streamer_messages_queue: asyncio.Queue):
 
 def streamer(config: LakeConfig):
     streamer_messages_queue: asyncio.Queue = asyncio.Queue(
-        maxsize=config.blocks_preload_pool_size
+        maxsize=config.preload_pool_size
     )
     stream_handle = asyncio.create_task(start(config, streamer_messages_queue))
     return stream_handle, streamer_messages_queue


### PR DESCRIPTION
The `blocks_preload_pool_size` has a default value of 200 and is used in the code to grab a list of blocks.
A variable with almost the same name `preload_pool_size` is one of the LakeConfig object parameters. This one can be set but isn't used anywhere. 
I believe the intent was for this to be 1 variable that the caller can set when creating the LakeConfig object.
I renamed `blocks_preload_pool_size` to `preload_pool_size` rather than the other way around to avoid any backward incompatibility.
